### PR TITLE
Added support for Choc Pro

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -72,6 +72,52 @@
 			<key>bInterfaceNumber</key>
 			<integer>1</integer>
 		</dict>
+		<key>Noppoo Choc Pro (primary)</key>
+		<dict>
+			<key>HIDDefaultBehavior</key>
+			<string></string>
+			<key>ReportDescriptorOverride</key>
+			<data>BQEJBqEBBQgZASkDFQAlAXUBlQORApUFkQEFBxngKeeVCIECGQQpKJUlgQIJTwlQCSsJLAlRCVIJU5UHgQIZWSlklQyBAsA=</data>
+			<key>CFBundleIdentifier</key>
+			<string>ryangoulden.driver.${PRODUCT_NAME:rfc1034Identifier}</string>
+			<key>IOClass</key>
+			<string>IOUSBHIDDriverDescriptorOverride</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBInterface</string>
+			<key>idVendor</key>
+			<integer>1267</integer>
+			<key>idProduct</key>
+			<integer>23130</integer>
+			<key>bcdDevice</key>
+			<integer>320</integer>
+			<key>bConfigurationValue</key>
+			<integer>1</integer>
+			<key>bInterfaceNumber</key>
+			<integer>0</integer>
+		</dict>
+		<key>Noppoo Choc Pro (secondary)</key>
+		<dict>
+			<key>HIDDefaultBehavior</key>
+			<string></string>
+			<key>ReportDescriptorOverride</key>
+			<data>BQwJAaEBhQEZACo8AhUAJjwClQF1EIEAwAUBCYChAYUCGYEpgxUAJQF1AZUDgQKVBYEBwAUBCQahAYUDBQcZPClOFQAlAZUTgQIJKQkqCS0JLpUEgQIZUylYlQaBAhkwKTuVDIECGYUpi5UHgQIZkCmWlQaBAgllCS+VAoECwA==</data>
+			<key>CFBundleIdentifier</key>
+			<string>ryangoulden.driver.${PRODUCT_NAME:rfc1034Identifier}</string>
+			<key>IOClass</key>
+			<string>IOUSBHIDDriverDescriptorOverride</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBInterface</string>
+			<key>idVendor</key>
+			<integer>1267</integer>
+			<key>idProduct</key>
+			<integer>23130</integer>
+			<key>bcdDevice</key>
+			<integer>320</integer>
+			<key>bConfigurationValue</key>
+			<integer>1</integer>
+			<key>bInterfaceNumber</key>
+			<integer>1</integer>
+		</dict>
 		<key>Griffin PowerMate</key>
 		<dict>
 			<key>ReportDescriptorOverride</key>


### PR DESCRIPTION
I'm sorry, I should've made a followup way sooner but somehow I managed to miss the previous notification. It turned out that only some device ID changes were enough for my keyboard to work.

I'm not sure what made me think that it only fixed half of the keys (maybe OS X's built in term?). I can't reproduce the problem but I remember that the kext did activate after I unplug the keyboard and plug it again, and there were some behavior changes, but it definitely works now. 

Thanks to you I can finally use OS X and for that I'm really grateful.
