### PR TITLE
Update Gemfile to include libusb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 gem "plist"
 gem "rake"
 gem 'rspec', :require => 'spec'
+gem "libusb"
 
 group :scan do
   gem "libusb"


### PR DESCRIPTION
Included `gem "libusb"` outside of the `:scan` group in order for `bundle install` to load necessary dependencies. Without this change, the error found in https://github.com/thefloweringash/iousbhiddriver-descriptor-override/issues/43#issuecomment-655863879 would appear.